### PR TITLE
domain change

### DIFF
--- a/mite.php
+++ b/mite.php
@@ -35,7 +35,7 @@ class mite {
 # CONSTANTS
 #######
     const MITE_PHP_VERSION = '1.2.7';
-	const MITE_DOMAIN = 'mite.yo.lk';
+	const MITE_DOMAIN = 'mite.de';
 	const REQUEST_TIMEOUT = 5;
 	const EXCEPTION_RSRC_NOT_FOUND = 100;
 	const EXCEPTION_UNPARSABLE_XML = 101;


### PR DESCRIPTION
Mite has changed it's domain from mite.yo.lk to mite.de

While the API is accessible through both domains for now, the old one might get shut down at some point.

https://mite.de/blog/2023/02/14/anstehender-umzug-auf-mite-de/